### PR TITLE
feat: 新增華語語音可用性提示與安裝說明頁

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,16 +1,47 @@
 <script setup lang="ts">
+import { onBeforeUnmount, watchEffect } from 'vue'
 import { RouterLink, RouterView } from 'vue-router'
 import HelloWorld from './components/HelloWorld.vue'
+import { useSpeechAvailability } from './composables/useSpeechAvailability'
 
 const linkClass =
 	'inline-block border-l border-stone-200 px-4 py-0.5 text-xs text-zinc-600 no-underline transition first:border-0 first:pl-0 hover:bg-emerald-500/15 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-emerald-400/10'
 const exactActiveClass = 'font-medium text-zinc-900 hover:bg-transparent dark:text-zinc-100 dark:hover:bg-transparent'
+const { voicePlaybackBlocked } = useSpeechAvailability()
+
+watchEffect(() => {
+	if (typeof document === 'undefined') return
+	const appRoot = document.getElementById('app')
+	if (!appRoot) return
+
+	appRoot.style.setProperty('--app-banner-height', voicePlaybackBlocked.value ? '2.875rem' : '0rem')
+})
+
+onBeforeUnmount(() => {
+	if (typeof document === 'undefined') return
+	const appRoot = document.getElementById('app')
+	if (!appRoot) return
+
+	appRoot.style.removeProperty('--app-banner-height')
+})
 </script>
 
 <template>
-	<header
-		class="fixed inset-x-0 top-0 z-[1000] border-b border-stone-200 bg-stone-50/95 backdrop-blur dark:border-zinc-800 dark:bg-zinc-950/95"
-	>
+	<header class="fixed inset-x-0 top-0 z-[1000] border-b border-stone-200 bg-stone-50/95 backdrop-blur dark:border-zinc-800 dark:bg-zinc-950/95">
+		<div
+			v-if="voicePlaybackBlocked"
+			class="border-b border-amber-300 bg-amber-100/95 dark:border-amber-900 dark:bg-amber-950/95"
+		>
+			<div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-2 px-4 py-2 text-sm text-amber-950 dark:text-amber-100">
+				<p class="m-0">目前沒有可用的華語語音<span class="hidden md:inline">，語音播放按鈕已暫時停用</span></p>
+				<RouterLink
+					to="/voice-install-guide"
+					class="rounded-md bg-amber-900 px-3 py-1 text-xs font-medium text-white no-underline transition hover:bg-amber-800 dark:bg-amber-200 dark:text-amber-950 dark:hover:bg-amber-100"
+				>
+					查看安裝說明
+				</RouterLink>
+			</div>
+		</div>
 		<div class="mx-auto max-w-7xl px-4 py-3 leading-snug">
 			<HelloWorld msg="自主學華文" />
 			<nav class="mt-3 w-full text-center">
@@ -43,6 +74,9 @@ const exactActiveClass = 'font-medium text-zinc-900 hover:bg-transparent dark:te
 				</RouterLink>
 				<RouterLink to="/mrt-quiz" :class="linkClass" :exact-active-class="exactActiveClass">
 					語音選站名
+				</RouterLink>
+				<RouterLink to="/voice-install-guide" :class="linkClass" :exact-active-class="exactActiveClass">
+					安裝語音
 				</RouterLink>
 				<a
 					href="https://www.moedict.tw"

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -34,6 +34,7 @@
 /* 為固定頂欄預留空間（與 App 頂欄高度對齊） */
 #app {
 	--app-header-height: 7.25rem;
+	--app-banner-height: 0rem;
 	@apply w-full font-normal;
-	padding: calc(var(--app-header-height) + 1rem) 0 0;
+	padding: calc(var(--app-header-height) + var(--app-banner-height) + 1rem) 0 0;
 }

--- a/src/components/ZhFlashCards.vue
+++ b/src/components/ZhFlashCards.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useSpeechAvailability } from '@/composables/useSpeechAvailability'
 import { getPreferredZhTwFemaleVoice, getVoicesAsync } from '@/utils/speechVoice'
 
 export interface FlashCardItem {
@@ -14,6 +15,7 @@ const props = defineProps<{
 
 const searchQuery = ref('')
 const speakingText = ref('')
+const { voicePlaybackAvailable, voicePlaybackBlocked } = useSpeechAvailability()
 
 const filteredCards = computed(() => {
 	const query = searchQuery.value.trim()
@@ -22,7 +24,7 @@ const filteredCards = computed(() => {
 })
 
 const speakChinese = async (text: string) => {
-	if (typeof window === 'undefined' || !window.speechSynthesis) return
+	if (!voicePlaybackAvailable.value || typeof window === 'undefined' || !window.speechSynthesis) return
 	if (!text.trim()) return
 
 	window.speechSynthesis.cancel()
@@ -83,7 +85,8 @@ const speakChinese = async (text: string) => {
 					</p>
 					<button
 						type="button"
-						class="shrink-0 cursor-pointer rounded-full border-0 bg-emerald-600 px-3 py-1.5 text-sm text-white transition hover:bg-emerald-700"
+						class="shrink-0 rounded-full border-0 bg-emerald-600 px-3 py-1.5 text-sm text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-45"
+						:disabled="voicePlaybackBlocked"
 						@click="speakChinese(card.chinese)"
 					>
 						{{ speakingText === card.chinese ? '朗讀中...' : '朗讀' }}

--- a/src/composables/useSpeechAvailability.ts
+++ b/src/composables/useSpeechAvailability.ts
@@ -1,0 +1,79 @@
+import { computed, ref } from 'vue'
+import { getPreferredZhTwFemaleVoice, getVoicesAsync } from '@/utils/speechVoice'
+
+type ClientPlatform = 'windows' | 'macos' | 'ios' | 'android' | 'linux' | 'chromeos' | 'unknown'
+
+const ttsSupported = ref(false)
+const zhTwVoiceAvailable = ref(false)
+const detectedPlatform = ref<ClientPlatform>('unknown')
+const speechAvailabilityChecked = ref(false)
+
+let initialized = false
+
+function detectPlatform(): ClientPlatform {
+  if (typeof navigator === 'undefined') return 'unknown'
+
+  const nav = navigator as Navigator & { userAgentData?: { platform?: string } }
+  const userAgentDataPlatform = nav.userAgentData?.platform?.toLowerCase() ?? ''
+  const platform = navigator.platform?.toLowerCase() ?? ''
+  const userAgent = navigator.userAgent.toLowerCase()
+  const combined = `${userAgentDataPlatform} ${platform} ${userAgent}`
+
+  if (
+    combined.includes('iphone') ||
+    combined.includes('ipad') ||
+    combined.includes('ipod') ||
+    combined.includes('ios')
+  ) {
+    return 'ios'
+  }
+  if (combined.includes('mac')) return 'macos'
+  if (combined.includes('android')) return 'android'
+  if (combined.includes('cros')) return 'chromeos'
+  if (combined.includes('win')) return 'windows'
+  if (combined.includes('linux')) return 'linux'
+  return 'unknown'
+}
+
+async function refreshSpeechAvailability() {
+  if (typeof window === 'undefined') return
+
+  ttsSupported.value = 'speechSynthesis' in window
+  detectedPlatform.value = detectPlatform()
+
+  if (!ttsSupported.value) {
+    zhTwVoiceAvailable.value = false
+    speechAvailabilityChecked.value = true
+    return
+  }
+
+  const voices = await getVoicesAsync()
+  zhTwVoiceAvailable.value = getPreferredZhTwFemaleVoice(voices) !== null
+  speechAvailabilityChecked.value = true
+}
+
+export function useSpeechAvailability() {
+  if (!initialized && typeof window !== 'undefined') {
+    initialized = true
+    void refreshSpeechAvailability()
+
+    if ('speechSynthesis' in window) {
+      window.speechSynthesis.addEventListener('voiceschanged', refreshSpeechAvailability)
+    }
+  }
+
+  const voicePlaybackAvailable = computed(() => ttsSupported.value && zhTwVoiceAvailable.value)
+  const voicePlaybackBlocked = computed(
+    () => speechAvailabilityChecked.value && !voicePlaybackAvailable.value,
+  )
+
+  return {
+    ttsSupported,
+    zhTwVoiceAvailable,
+    voicePlaybackAvailable,
+    voicePlaybackBlocked,
+    speechAvailabilityChecked,
+    detectedPlatform,
+    refreshSpeechAvailability,
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -58,6 +58,11 @@ const router = createRouter({
       component: () => import('../views/MrtQuizPage.vue'),
     },
     {
+      path: '/voice-install-guide',
+      name: 'voice-install-guide',
+      component: () => import('../views/VoiceInstallGuidePage.vue'),
+    },
+    {
       path: '/flashcards/body',
       name: 'flashcards-body',
       component: () => import('../views/BodyPage.vue'),

--- a/src/views/BannanLineQuizPage.vue
+++ b/src/views/BannanLineQuizPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useSpeechAvailability } from '@/composables/useSpeechAvailability'
 import { getPreferredZhTwFemaleVoice, getVoicesAsync } from '@/utils/speechVoice'
 
 type Station = { id: string; name: string; pronunciation?: string; hint: string }
@@ -244,6 +245,7 @@ let fwParticles: Array<{
 let fwRunning = false
 let fwRaf: number | null = null
 let speakSessionId = 0
+const { voicePlaybackAvailable, voicePlaybackBlocked } = useSpeechAvailability()
 
 async function refreshZhVoice() {
   if (!ttsSupported) return
@@ -285,7 +287,7 @@ function attachUtterance(
 }
 
 function speakText(text: string, onEnd?: () => void) {
-  if (!ttsSupported || !voiceEnabled.value || !zhVoice.value) {
+  if (!ttsSupported || !voicePlaybackAvailable.value || !voiceEnabled.value || !zhVoice.value) {
     onEnd?.()
     return
   }
@@ -299,7 +301,7 @@ function getSpokenStationName(name: string): string {
 }
 
 async function speakOptionsSequentially() {
-  if (!ttsSupported || !zhVoice.value || current.value >= pool.value.length) return
+  if (!ttsSupported || !voicePlaybackAvailable.value || !zhVoice.value || current.value >= pool.value.length) return
   const sessionId = ++speakSessionId
   replayBusy.value = true
   window.speechSynthesis.cancel()
@@ -333,7 +335,7 @@ async function speakOptionsSequentially() {
 }
 
 function speakStationLabel(name: string) {
-  if (!ttsSupported || !voiceEnabled.value || !zhVoice.value) return
+  if (!ttsSupported || !voicePlaybackAvailable.value || !voiceEnabled.value || !zhVoice.value) return
   labelFlashName.value = name
   window.setTimeout(() => {
     if (labelFlashName.value === name) labelFlashName.value = null
@@ -343,7 +345,7 @@ function speakStationLabel(name: string) {
 }
 
 function speakFeedback(isRight: boolean, name: string) {
-  if (!voiceEnabled.value || !ttsSupported) return
+  if (!voicePlaybackAvailable.value || !voiceEnabled.value || !ttsSupported) return
   const spokenName = getSpokenStationName(name)
   const msg = isRight ? `答對了！這站是${spokenName}` : `答錯了，正確答案是${spokenName}`
   speakText(msg)
@@ -502,6 +504,15 @@ watch(voiceEnabled, (on) => {
   if (!on) stopSpeech()
 })
 
+watch(voicePlaybackBlocked, (blocked) => {
+  if (blocked) {
+    voiceEnabled.value = false
+    stopSpeech()
+    return
+  }
+  voiceEnabled.value = true
+})
+
 watch(selectedLineKey, () => {
   const key = normalizeLineKey(selectedLineKey.value)
   if (selectedLineKey.value !== key) selectedLineKey.value = key
@@ -529,6 +540,9 @@ onMounted(() => {
   void refreshZhVoice()
   if (ttsSupported) {
     window.speechSynthesis.addEventListener('voiceschanged', refreshZhVoice)
+  }
+  if (voicePlaybackBlocked.value) {
+    voiceEnabled.value = false
   }
   initFireworks()
   if (shouldInitImmediately) initGame()
@@ -701,10 +715,11 @@ watch(fireworksCanvas, (c) => {
 				</select>
 			</div>
 			<div
-				v-if="!ttsSupported"
+				v-if="!ttsSupported || voicePlaybackBlocked"
 				class="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-slate-600 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-100"
 			>
-				此瀏覽器不支援語音播報功能，建議使用 Chrome 或 Edge。
+				<span v-if="!ttsSupported">此瀏覽器不支援語音播報功能，建議使用 Chrome 或 Edge。</span>
+				<span v-else>目前沒有可用的華語語音，語音題目與站名播放已停用。</span>
 			</div>
 			<div
 				v-else
@@ -771,9 +786,10 @@ watch(fireworksCanvas, (c) => {
 							<button
 								v-else
 								type="button"
-								class="station-label clickable"
+								class="station-label clickable disabled:cursor-not-allowed disabled:opacity-45"
 								:title="'點我聽讀：' + s.name"
 								:class="{ 'label-speaking': labelFlashName === s.name }"
+								:disabled="voicePlaybackBlocked || !voiceEnabled"
 								@click="speakStationLabel(s.name)"
 							>
 								{{ s.name }}

--- a/src/views/CustomPage.vue
+++ b/src/views/CustomPage.vue
@@ -76,8 +76,9 @@
 				<div class="flex flex-wrap items-center gap-3">
 					<button
 						type="button"
-						class="cursor-pointer rounded border-0 px-4 py-2 text-base font-medium text-white transition hover:opacity-90"
+						class="rounded border-0 px-4 py-2 text-base font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-45"
 						:class="isSpeaking ? 'bg-red-500' : 'bg-emerald-500'"
+						:disabled="voicePlaybackBlocked"
 						@click="toggleSpeech"
 					>
 						{{ isSpeaking ? '停止朗讀' : '開始朗讀' }}
@@ -91,6 +92,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref } from 'vue'
+import { useSpeechAvailability } from '@/composables/useSpeechAvailability'
 import { ZH_TW_PREFERRED_KEYWORDS, getPreferredVoice, getVoicesAsync } from '@/utils/speechVoice'
 
 const rawText = ref(`人之初，性本善，性相近，習相遠。
@@ -100,6 +102,7 @@ const rawCsv = ref(`教,叫
 為人子,危人子`)
 
 const isSpeaking = ref(false)
+const { voicePlaybackAvailable, voicePlaybackBlocked } = useSpeechAvailability()
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
@@ -175,7 +178,7 @@ const createUtterance = async () => {
 }
 
 const toggleSpeech = async () => {
-	if (typeof window === 'undefined' || !window.speechSynthesis) return
+	if (!voicePlaybackAvailable.value || typeof window === 'undefined' || !window.speechSynthesis) return
 
 	if (isSpeaking.value) {
 		window.speechSynthesis.cancel()

--- a/src/views/MrtQuizPage.vue
+++ b/src/views/MrtQuizPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useSpeechAvailability } from '@/composables/useSpeechAvailability'
 import { getPreferredZhTwFemaleVoice, getVoicesAsync } from '../utils/speechVoice'
 
 interface Station {
@@ -60,9 +61,10 @@ const score = ref(0)
 const streak = ref(0)
 const showReward = ref(false)
 const totalAnswered = ref(0)
+const { voicePlaybackAvailable, voicePlaybackBlocked } = useSpeechAvailability()
 
 async function speak() {
-	if (typeof window === 'undefined' || !window.speechSynthesis) return
+	if (!voicePlaybackAvailable.value || typeof window === 'undefined' || !window.speechSynthesis) return
 	const voices = await getVoicesAsync()
 	const utterance = new SpeechSynthesisUtterance(question.value.correct.name)
 	utterance.lang = 'zh-TW'
@@ -151,7 +153,8 @@ onMounted(() => {
 		>
 			<button
 				type="button"
-				class="mb-5 cursor-pointer rounded-lg border border-stone-300 bg-transparent px-4 py-1.5 text-base text-zinc-800 transition hover:border-emerald-500/80 dark:border-zinc-600 dark:text-zinc-200"
+				class="mb-5 rounded-lg border border-stone-300 bg-transparent px-4 py-1.5 text-base text-zinc-800 transition hover:border-emerald-500/80 disabled:cursor-not-allowed disabled:opacity-45 dark:border-zinc-600 dark:text-zinc-200"
+				:disabled="voicePlaybackBlocked"
 				@click="speak"
 			>
 				🔊 再聽一次

--- a/src/views/ThreeCharacterPage.vue
+++ b/src/views/ThreeCharacterPage.vue
@@ -11,7 +11,8 @@
 			</div>
 			<button
 				type="button"
-				class="min-w-[120px] cursor-pointer rounded border-0 bg-emerald-500 px-4 py-2 text-base font-medium text-white transition hover:bg-emerald-600"
+				class="min-w-[120px] rounded border-0 bg-emerald-500 px-4 py-2 text-base font-medium text-white transition hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-45"
+				:disabled="voicePlaybackBlocked"
 				@click="toggleSpeech"
 			>
 				{{ isSpeaking ? '暫停' : '朗讀' }}
@@ -22,6 +23,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref } from 'vue'
+import { useSpeechAvailability } from '@/composables/useSpeechAvailability'
 import { ZH_TW_PREFERRED_KEYWORDS, getPreferredVoice, getVoicesAsync } from '@/utils/speechVoice'
 
 const text = `人之初，性本善，性相近，習相遠。
@@ -41,6 +43,7 @@ const homophoneMap: Record<string, string> = {
 }
 
 const isSpeaking = ref(false)
+const { voicePlaybackAvailable, voicePlaybackBlocked } = useSpeechAvailability()
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
@@ -78,7 +81,7 @@ const createUtterance = async () => {
 }
 
 const toggleSpeech = async () => {
-	if (typeof window === 'undefined' || !window.speechSynthesis) return
+	if (!voicePlaybackAvailable.value || typeof window === 'undefined' || !window.speechSynthesis) return
 
 	if (isSpeaking.value) {
 		window.speechSynthesis.cancel()

--- a/src/views/VoiceInstallGuidePage.vue
+++ b/src/views/VoiceInstallGuidePage.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useSpeechAvailability } from '@/composables/useSpeechAvailability'
+
+const { detectedPlatform } = useSpeechAvailability()
+
+const guide = computed(() => {
+  switch (detectedPlatform.value) {
+    case 'windows':
+      return {
+        title: 'Windows 安裝華語語音',
+        steps: [
+          '開啟「設定」>「時間與語言」>「語言與地區」。',
+          '在慣用語言中加入「中文（台灣）」；若已存在，點進該語言的選項頁。',
+          '在語言功能中安裝「語音」或「Text-to-speech」。',
+          '安裝完成後重新開啟 Chrome 或 Edge，再回到本站測試。',
+        ],
+      }
+    case 'macos':
+      return {
+        title: 'macOS 安裝華語語音',
+        steps: [
+          '開啟「系統設定」>「輔助使用」>「朗讀內容」。',
+          '在系統聲音或 Voice 區域新增中文語音，優先選台灣中文相關聲音。',
+          '若看到下載按鈕，先完成語音下載。',
+          '重新開啟瀏覽器後回到本站測試。',
+        ],
+      }
+    case 'ios':
+      return {
+        title: 'iPhone / iPad 安裝華語語音',
+        steps: [
+          '開啟「設定」>「輔助使用」>「朗讀內容」>「聲音」。',
+          '選擇「中文」並下載台灣中文或華語相關聲音。',
+          '安裝後重新開啟 Safari 或 Chrome。',
+          '回到本站後再試一次語音播放。',
+        ],
+      }
+    case 'android':
+      return {
+        title: 'Android 安裝華語語音',
+        steps: [
+          '開啟手機「設定」並搜尋「文字轉語音」或「Text-to-speech」。',
+          '進入 Google 文字轉語音輸出或裝置的 TTS 設定。',
+          '下載或啟用中文（台灣）/ 華語語音資料。',
+          '重新開啟瀏覽器並返回本站測試。',
+        ],
+      }
+    case 'chromeos':
+      return {
+        title: 'ChromeOS 安裝華語語音',
+        steps: [
+          '開啟「設定」>「進階」>「無障礙設定」。',
+          '找到文字轉語音相關設定並啟用語音功能。',
+          '下載或加入中文（台灣）語音。',
+          '重新啟動瀏覽器分頁後回到本站測試。',
+        ],
+      }
+    case 'linux':
+      return {
+        title: 'Linux 設定華語語音',
+        steps: [
+          '先確認目前桌面環境或瀏覽器使用的 TTS 引擎是什麼。',
+          '安裝可供瀏覽器存取的中文（台灣）語音套件或語音引擎。',
+          '若是 Chromium / Chrome，安裝後請完整重開瀏覽器。',
+          '回到本站測試；若仍無語音，建議改用 Chrome 或 Edge on Windows / macOS。',
+        ],
+      }
+    default:
+      return {
+        title: '安裝華語語音',
+        steps: [
+          '請先確認目前瀏覽器支援 Web Speech API，建議使用最新版 Chrome、Edge 或 Safari。',
+          '在作業系統的語言或輔助使用設定中，安裝中文（台灣）或華語語音。',
+          '安裝後完整重新開啟瀏覽器，再回到本站測試。',
+        ],
+      }
+  }
+})
+</script>
+
+<template>
+  <section class="mx-auto max-w-3xl px-4 pb-12 pt-6">
+    <header class="rounded-2xl border border-amber-200 bg-amber-50 px-5 py-5 shadow-sm dark:border-amber-900 dark:bg-amber-950/30">
+      <p class="m-0 text-sm font-medium text-amber-900 dark:text-amber-100">語音安裝說明</p>
+      <h1 class="mt-2 text-3xl font-bold text-zinc-900 dark:text-zinc-50">
+        {{ guide.title }}
+      </h1>
+      <p class="mt-3 text-sm leading-6 text-zinc-700 dark:text-zinc-300">
+        本頁會依照你目前的作業系統提供安裝方向。完成安裝後，請重新開啟瀏覽器，讓新的語音資料被載入。
+      </p>
+    </header>
+
+    <section class="mt-5 rounded-2xl border border-stone-200 bg-white px-5 py-5 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
+      <ol class="m-0 list-decimal space-y-3 pl-5 text-zinc-800 dark:text-zinc-100">
+        <li v-for="step in guide.steps" :key="step">{{ step }}</li>
+      </ol>
+    </section>
+
+    <section class="mt-5 rounded-2xl border border-stone-200 bg-stone-50 px-5 py-5 text-sm leading-6 text-zinc-700 shadow-sm dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300">
+      <p class="m-0">如果你已安裝語音但本站仍顯示不可用，通常是瀏覽器尚未重新載入語音清單。</p>
+      <p class="mb-0 mt-2">建議操作：關閉所有本站分頁、完整重開瀏覽器，再重新進入。</p>
+    </section>
+  </section>
+</template>

--- a/src/views/WhatIsThisPage.vue
+++ b/src/views/WhatIsThisPage.vue
@@ -72,14 +72,16 @@
 					<div class="flex flex-wrap gap-2">
 						<button
 							type="button"
-							class="cursor-pointer rounded border-0 bg-emerald-500 px-4 py-2 text-base text-white transition hover:bg-emerald-600"
+							class="rounded border-0 bg-emerald-500 px-4 py-2 text-base text-white transition hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-45"
+							:disabled="voicePlaybackBlocked"
 							@click="playZhAudio"
 						>
 							播放華文發音
 						</button>
 						<button
 							type="button"
-							class="cursor-pointer rounded border-0 bg-teal-600 px-4 py-2 text-base text-white transition hover:bg-teal-700"
+							class="rounded border-0 bg-teal-600 px-4 py-2 text-base text-white transition hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-45"
+							:disabled="voicePlaybackBlocked"
 							@click="playEnAudio"
 						>
 							播放英文發音
@@ -102,6 +104,7 @@
 import { defineComponent, ref, onUnmounted } from 'vue'
 import heic2any from 'heic2any'
 import Pica from 'pica'
+import { useSpeechAvailability } from '@/composables/useSpeechAvailability'
 import {
 	EN_US_PREFERRED_KEYWORDS,
 	ZH_TW_PREFERRED_KEYWORDS,
@@ -112,6 +115,7 @@ export default defineComponent({
 	name: 'WhatIsThisPage',
 
 	setup() {
+		const { voicePlaybackAvailable, voicePlaybackBlocked } = useSpeechAvailability()
 		const FAVORITES_KEY = 'en_love_arr'
 		const imagePreview = ref('')
 		const loading = ref(false)
@@ -347,10 +351,12 @@ export default defineComponent({
 		}
 
 		const playZhAudio = () => {
+			if (!voicePlaybackAvailable.value) return
 			speakTextWithPreferredVoice(resultZh.value, 'zh-TW', ZH_TW_PREFERRED_KEYWORDS, 0.72)
 		}
 
 		const playEnAudio = () => {
+			if (!voicePlaybackAvailable.value) return
 			speakTextWithPreferredVoice(resultEn.value, 'en-US', EN_US_PREFERRED_KEYWORDS)
 		}
 
@@ -415,6 +421,8 @@ export default defineComponent({
 			onFileChange,
 			playZhAudio,
 			playEnAudio,
+			voicePlaybackAvailable,
+			voicePlaybackBlocked,
 			videoRef,
 			showCamera,
 			openCamera,


### PR DESCRIPTION
## Summary

這次修改針對瀏覽器沒有可用台灣華語語音的情境補上完整處理流程。除了統一停用各頁面的語音播放按鈕，也在頂部加入固定提示，並新增依照使用者作業系統顯示的語音安裝說明頁，降低使用者不知道如何排除問題的情況。

  ## Changes

  - 新增共用的語音可用性判斷 composable，集中檢查 speechSynthesis 是否可用、是否存在可用的 zh-TW 語音，以及目前使用者作業系統。
  - 在全站頂部導覽區加入固定提示訊息，當沒有可用華語語音時顯示提醒與「查看安裝說明」入口。
  - 新增 /voice-install-guide 路由與安裝說明頁，依 Windows、macOS、iOS、Android、ChromeOS、Linux 顯示對應安裝步驟。
  - 調整 #app 的 padding-top 計算方式，讓頂部提示出現時內容區會跟著下移，避免被 fixed header 蓋住。
  - 將字卡、自訂朗讀、三字經、AI 圖片學、捷運語音測驗與站名學習頁的語音按鈕統一接上停用狀態。
  - 在板南線/捷運站名學習頁中，沒有可用華語語音時一併停用語音題目播放、站名點讀與相關語音控制。

  ## Impact

  - 影響範圍主要是前端 UI、語音播放行為與導覽流程。
  - 沒有修改 API、資料庫 schema、後端權限或部署流程。
  - 使用者在缺少可用華語語音時，原本可點擊的語音操作現在會明確停用，不再出現按了沒反應的狀況。
  - 作業系統判斷依賴瀏覽器提供的 user agent / platform 資訊，少數環境可能退回通用安裝說明。

  ## Risks / Notes

  - src/composables/useSpeechAvailability.ts 目前使用瀏覽器端 heuristics 判斷作業系統，若瀏覽器回傳資訊不完整，會落到通用安裝說明。
  - #app 的頂部間距目前透過 CSS 變數與 watchEffect 動態更新，若後續 header 高度再調整，需同步檢查 --app-header-height 與 banner 高度設定。

## 畫面截圖

<img width="1417" height="915" alt="image" src="https://github.com/user-attachments/assets/238e6552-0ddc-4547-b209-08bfc163f0aa" />

<img width="1417" height="915" alt="image" src="https://github.com/user-attachments/assets/18b00248-7753-4288-877f-07860d45b7b9" />
