### PR TITLE
fix: scroll to top on route changes

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,11 @@ import HomeView from '../views/HomeView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
+  scrollBehavior(to, from) {
+    if (to.fullPath === from.fullPath) return false
+
+    return { left: 0, top: 0 }
+  },
   routes: [
     {
       path: '/',


### PR DESCRIPTION
## Summary

這次修改讓使用者在切換到不同路由時，頁面會自動滾動到最上方。這可以避免從長頁面切換到其他頁面時，仍停留在先前的捲動位置，造成新頁面內容一開始不可見。

## Changes

- 在 Vue Router 設定中加入全域 `scrollBehavior`
- 當目標路由與來源路由的 `fullPath` 不同時，回到頁面左上角
- 若路由未實際變更，保留既有捲動狀態

## Impact

- 影響所有透過 Vue Router 進行的頁面切換
- 不影響 API、資料庫 schema、權限或背景作業
- 不新增依賴，也不改動各頁面元件本身
